### PR TITLE
Add missing requires

### DIFF
--- a/spec/lib/tepee_spec.rb
+++ b/spec/lib/tepee_spec.rb
@@ -1,5 +1,7 @@
 require 'spec_helper'
 require 'tepee'
+require 'securerandom'
+
 describe Tepee do
   # a value with a corresponding override in env
   VALUE1_VALUE = 'value1:' + SecureRandom.uuid


### PR DESCRIPTION
`SecureRandom` is part of the Ruby standard library and needs to be
required in order to be used.