### PR TITLE
Stop support for Ruby 2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ before_install:
   - gem install bundler
 
 rvm:
-  - 2.2
   - 2.3
   - 2.4
   - 2.5

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 # A sample Gemfile
 source 'https://rubygems.org'
-ruby '>= 2.2.0'
+ruby '>= 2.3.0'
 
 group :development do
   gem 'rspec'

--- a/tepee.gemspec
+++ b/tepee.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.name = 'tepee'
   s.version = Tepee::Version::STRING
   s.platform = Gem::Platform::RUBY
-  s.required_ruby_version = '>= 2.2.0'
+  s.required_ruby_version = '>= 2.3.0'
   s.authors = ['Alexandre Ignjatovic', 'Robin Sfez', 'Benoit Tigeot', 'Christophe Valentin']
   s.description = <<-EOF
     A ruby configuration helper for the braves.


### PR DESCRIPTION
https://www.ruby-lang.org/en/news/2018/06/20/support-of-ruby-2-2-has-ended/